### PR TITLE
Fix: Use Capybara#fill_in for appending to publisher

### DIFF
--- a/features/support/publishing_cuke_helpers.rb
+++ b/features/support/publishing_cuke_helpers.rb
@@ -5,8 +5,9 @@ module PublishingCukeHelpers
 
   def append_to_publisher(txt)
     status_message_text = find("#status_message_text").value
-    find("#status_message_text").native.send_key(" #{txt}")
-    expect(page).to have_field("status_message[text]", with: "#{status_message_text} #{txt}")
+    fill_in id: "status_message_text", with: "#{status_message_text} #{txt}"
+    # trigger JavaScript event listeners
+    find("#status_message_text").native.send_key(:end)
   end
 
   def upload_file_with_publisher(path)


### PR DESCRIPTION
Capybara's `native#send_key` function is slow when it is passed a string
longer than just a few characters. This often results in timeout issues
and Capybara (falsely) reporting feature as failing.

To fix this, we use the faster function` #fill_in`. This does not trigger
JavaScript events on the input, so we manually trigger them after
`#fill_in` by just sending a single key. This can be any key but since we
do not want to modify the text in the input, non-text keys should be
used. For a list of non-text keys, see
http://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FNode%2FElement%3Asend_keys

There is an alternative to the above:
1. Use `#fill_in` to enter all text except for the last character:  
      
       fill_in ..., with: "#{status_message_text} #{txt[0..-2]}"
      
1. And then use `#send_key` to send that last character:

       find("#status_message_text").native.send_key(txt.last)

At the moment, both approaches work equally well but the second approach
is documented here just in case it becomes relevant in the future.